### PR TITLE
Implement cmd/nsight-proxy tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Tento projekt poskytuje nástroje příkazové řádky a (v budoucnu) API server
 
 ## Dostupné Nástroje
 
-Projekt obsahuje dva hlavní nástroje v adresáři `cmd/`:
+Projekt obsahuje tři hlavní nástroje v adresáři `cmd/`:
 
 ### 1. `getdata` - Komplexní API nástroj
 
@@ -323,6 +323,31 @@ Výstupem je pole objektů, kde každý objekt reprezentuje klienta a obsahuje v
   // ... dalsi klienti
 ]
 ```
+
+### 3. `nsight-proxy` - JSON API Proxy Server
+
+HTTP proxy server, který převádí N-Sight XML API na JSON formát. Poslouchá na portu 80 a poskytuje stejné API volání jako originální N-Sight, ale s JSON výstupem místo XML.
+
+**Spuštění:**
+
+```bash
+go run cmd/nsight-proxy/main.go
+```
+
+**Použití:**
+
+```bash
+# Získání seznamu klientů ve formátu JSON
+curl "http://localhost/api/?service=list_clients"
+
+# Získání serverů pro site 123
+curl "http://localhost/api/?service=list_servers&siteid=123"
+
+# Health check
+curl "http://localhost/health"
+```
+
+Proxy server podporuje všechna API volání stejně jako nástroj `getdata`, ale poskytuje je přes HTTP rozhraní s JSON výstupem. Více informací v [dokumentaci proxy serveru](cmd/nsight-proxy/README.md).
 
 ## API Server (`cmd/server`)
 

--- a/README.md
+++ b/README.md
@@ -338,10 +338,10 @@ go run cmd/nsight-proxy/main.go
 
 ```bash
 # Získání seznamu klientů ve formátu JSON
-curl "http://localhost/api/?service=list_clients"
+curl "http://localhost/api/?apikey=YOUR_API_KEY&service=list_clients"
 
 # Získání serverů pro site 123
-curl "http://localhost/api/?service=list_servers&siteid=123"
+curl "http://localhost/api/?apikey=YOUR_API_KEY&service=list_servers&siteid=123"
 
 # Health check
 curl "http://localhost/health"

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ set -e
 PLATFORMS=("windows/amd64" "windows/arm64" "linux/amd64" "linux/arm64" "darwin/amd64" "darwin/arm64")
 
 # Define commands to build (corresponds to directories in cmd/)
-COMMANDS=("getdata" "fetchall" "server")
+COMMANDS=("getdata" "fetchall" "server" "nsight-proxy")
 
 # Output directory
 OUTPUT_DIR="bin"

--- a/cmd/nsight-proxy/README.md
+++ b/cmd/nsight-proxy/README.md
@@ -12,21 +12,21 @@ N-Sight JSON Proxy je HTTP server, který funguje jako proxy a převodník pro N
 
 ## Konfigurace
 
-Proxy server vyžaduje stejnou konfiguraci jako ostatní nástroje v tomto projektu:
+Proxy server vyžaduje pouze konfiguraci N-Sight serveru. API klíč se předává v každém požadavku:
 
 ### Proměnné prostředí
 
 ```bash
-NSIGHT_API_KEY=your_api_key_here
 NSIGHT_SERVER=your.nsight.server.com
 ```
 
 ### .env soubor
 
 ```env
-NSIGHT_API_KEY=your_api_key_here
 NSIGHT_SERVER=your.nsight.server.com
 ```
+
+**Poznámka**: API klíč se nepředává přes .env soubor, ale musí být součástí každého HTTP požadavku jako parametr `apikey`. Tím se zajistí bezpečnost - každý uživatel musí použít svůj vlastní API klíč.
 
 ## Spuštění
 
@@ -48,24 +48,26 @@ Server se spustí na portu 80 a bude dostupný na:
 Formát volání je stejný jako originální N-Sight API, pouze s JSON výstupem:
 
 ```
-http://localhost/api/?service=<service_name>&<parameters>
+http://localhost/api/?apikey=<your_api_key>&service=<service_name>&<parameters>
 ```
+
+**Důležité**: Každý požadavek musí obsahovat parametr `apikey` s platným N-Sight API klíčem.
 
 ### Příklady volání
 
 #### Získání seznamu klientů
 ```bash
-curl "http://localhost/api/?service=list_clients"
+curl "http://localhost/api/?apikey=YOUR_API_KEY&service=list_clients"
 ```
 
 #### Získání serverů pro konkrétní site
 ```bash
-curl "http://localhost/api/?service=list_servers&siteid=123"
+curl "http://localhost/api/?apikey=YOUR_API_KEY&service=list_servers&siteid=123"
 ```
 
 #### Získání informací o zařízení
 ```bash
-curl "http://localhost/api/?service=list_device_asset_details&deviceid=456"
+curl "http://localhost/api/?apikey=YOUR_API_KEY&service=list_device_asset_details&deviceid=456"
 ```
 
 ## Podporované služby
@@ -165,9 +167,17 @@ Server loguje všechny příchozí požadavky a chyby do standardního výstupu:
 
 ## Bezpečnost
 
-- Server vyžaduje správnou konfiguraci API klíče a serveru
-- Všechny chyby jsou bezpečně zpracovány bez odhalení citlivých informací
-- CORS je nakonfigurován permisivně pro vývojové účely
+- **API klíč v URL**: Každý uživatel musí poskytnout svůj vlastní API klíč v každém požadavku
+- **Žádné sdílené klíče**: Server neuchovává žádné API klíče, což eliminuje bezpečnostní rizika
+- **Validace**: Server validuje přítomnost API klíče a serveru před zpracováním požadavku
+- **Chybové zprávy**: Všechny chyby jsou bezpečně zpracovány bez odhalení citlivých informací
+- **CORS**: Nakonfigurován permisivně pro vývojové účely - v produkci doporučujeme omezit domény
+
+**Důležité pro produkční nasazení:**
+- Používejte HTTPS pro ochranu API klíče v přenosu
+- Omezte CORS politiky na konkrétní domény
+- Implementujte rate limiting pro ochranu před zneužitím
+- Monitorujte přístup k API endpointům
 
 ## Build
 

--- a/cmd/nsight-proxy/README.md
+++ b/cmd/nsight-proxy/README.md
@@ -1,0 +1,180 @@
+# N-Sight JSON Proxy
+
+N-Sight JSON Proxy je HTTP server, který funguje jako proxy a převodník pro N-Sight API. Přijímá HTTP požadavky stejně jako originální N-Sight API, ale vrací data ve formátu JSON místo XML.
+
+## Funkcionalita
+
+- **HTTP Server**: Poslouchá na portu 80
+- **API Proxy**: Předává volání na nakonfigurovaný N-Sight endpoint
+- **XML→JSON Konverze**: Automaticky převádí XML odpovědi na JSON formát
+- **Plná kompatibilita**: Podporuje všechny dostupné N-Sight API služby
+- **CORS podpora**: Umožňuje cross-origin requests pro webové aplikace
+
+## Konfigurace
+
+Proxy server vyžaduje stejnou konfiguraci jako ostatní nástroje v tomto projektu:
+
+### Proměnné prostředí
+
+```bash
+NSIGHT_API_KEY=your_api_key_here
+NSIGHT_SERVER=your.nsight.server.com
+```
+
+### .env soubor
+
+```env
+NSIGHT_API_KEY=your_api_key_here
+NSIGHT_SERVER=your.nsight.server.com
+```
+
+## Spuštění
+
+```bash
+# Spustit proxy server
+./nsight-proxy
+
+# Nebo pomocí go run
+go run cmd/nsight-proxy/main.go
+```
+
+Server se spustí na portu 80 a bude dostupný na:
+- API endpoint: `http://localhost/api/`
+- Health check: `http://localhost/health`
+- Info endpoint: `http://localhost/`
+
+## Použití
+
+Formát volání je stejný jako originální N-Sight API, pouze s JSON výstupem:
+
+```
+http://localhost/api/?service=<service_name>&<parameters>
+```
+
+### Příklady volání
+
+#### Získání seznamu klientů
+```bash
+curl "http://localhost/api/?service=list_clients"
+```
+
+#### Získání serverů pro konkrétní site
+```bash
+curl "http://localhost/api/?service=list_servers&siteid=123"
+```
+
+#### Získání informací o zařízení
+```bash
+curl "http://localhost/api/?service=list_device_asset_details&deviceid=456"
+```
+
+## Podporované služby
+
+Proxy server podporuje všechny služby dostupné v původním N-Sight API:
+
+### Clients, Sites a Devices
+- `list_clients` - Seznam všech klientů
+- `list_sites` - Seznam site pro klienta (parametr: `clientid`)
+- `list_servers` - Seznam serverů pro site (parametr: `siteid`)
+- `list_workstations` - Seznam workstation pro site (parametr: `siteid`)
+- `list_devices` - Seznam zařízení pro site (parametr: `siteid`)
+- `list_devices_at_client` - Seznam zařízení pro klienta (parametr: `clientid`)
+- `list_device_asset_details` - Detaily asset pro zařízení (parametr: `deviceid`)
+- `list_device_monitoring_details` - Monitoring detaily zařízení (parametr: `deviceid`)
+- `list_agentless_assets` - Agentless assets pro site (parametr: `siteid`)
+
+### Checks a Results
+- `list_failing_checks` - Seznam selhávajících kontrol
+- `list_checks` - Seznam kontrol pro zařízení/site (parametry: `deviceid` nebo `siteid`)
+
+### Asset Tracking
+- `list_hardware` - Hardware informace (parametr: `deviceid`)
+- `list_software` - Software informace (parametr: `deviceid`)
+- `list_license_groups` - Skupiny licencí
+
+### Patch Management
+- `list_patches` - Seznam patchů pro zařízení (parametr: `deviceid`)
+
+### Antivirus
+- `list_antivirus_products` - Podporované antivirus produkty
+- `list_antivirus_definitions` - Definice antiviru (parametr: `deviceid`)
+- `list_quarantine` - Seznam karantény (parametr: `deviceid`)
+
+### Performance
+- `list_performance_history` - Historie výkonu (parametry: `deviceid`, `checkid`, `startdate`, `enddate`)
+- `list_drive_space_history` - Historie místa na disku (parametry: `deviceid`, `startdate`, `enddate`)
+
+### Templates
+- `list_templates` - Seznam monitorovacích šablon
+
+## Response Format
+
+Všechny odpovědi jsou ve formátu JSON:
+
+### Úspěšná odpověď
+```json
+[
+  {
+    "client_id": 123,
+    "client_name": "Example Client",
+    "contact_name": "John Doe",
+    ...
+  }
+]
+```
+
+### Chybová odpověď
+```json
+{
+  "error": "Error description"
+}
+```
+
+## Health Check
+
+Server poskytuje health check endpoint pro monitoring:
+
+```bash
+curl http://localhost/health
+```
+
+Odpověď:
+```json
+{
+  "status": "ok",
+  "service": "nsight-proxy"
+}
+```
+
+## CORS podpora
+
+Server automaticky přidává CORS hlavičky pro podporu webových aplikací:
+- `Access-Control-Allow-Origin: *`
+- `Access-Control-Allow-Methods: GET, POST, OPTIONS`
+- `Access-Control-Allow-Headers: Content-Type`
+
+## Logování
+
+Server loguje všechny příchozí požadavky a chyby do standardního výstupu:
+
+```
+2024/01/01 12:00:00 Starting N-Sight JSON Proxy Server...
+2024/01/01 12:00:00 Server starting on port 80...
+2024/01/01 12:00:01 Handling request for service: list_clients
+```
+
+## Bezpečnost
+
+- Server vyžaduje správnou konfiguraci API klíče a serveru
+- Všechny chyby jsou bezpečně zpracovány bez odhalení citlivých informací
+- CORS je nakonfigurován permisivně pro vývojové účely
+
+## Build
+
+Nástroj se automaticky builduje pomocí build scriptu:
+
+```bash
+./build.sh
+```
+
+Výsledný binární soubor bude dostupný v `bin/` adresáři pro všechny podporované platformy.

--- a/cmd/nsight-proxy/main.go
+++ b/cmd/nsight-proxy/main.go
@@ -1,0 +1,284 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"nsight-proxy/internal/nsight"
+)
+
+// ProxyServer wraps the nsight API client
+type ProxyServer struct {
+	client *nsight.ApiClient
+}
+
+// NewProxyServer creates a new proxy server instance
+func NewProxyServer() (*ProxyServer, error) {
+	client, err := nsight.NewApiClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create N-Sight API client: %w", err)
+	}
+	
+	return &ProxyServer{client: client}, nil
+}
+
+// handleAPI routes API requests based on service parameter
+func (ps *ProxyServer) handleAPI(w http.ResponseWriter, r *http.Request) {
+	// Set CORS headers
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	w.Header().Set("Content-Type", "application/json")
+
+	// Handle preflight requests
+	if r.Method == "OPTIONS" {
+		return
+	}
+
+	// Only accept GET requests
+	if r.Method != "GET" {
+		http.Error(w, `{"error": "Only GET method is supported"}`, http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract service parameter
+	service := r.URL.Query().Get("service")
+	if service == "" {
+		http.Error(w, `{"error": "Missing service parameter"}`, http.StatusBadRequest)
+		return
+	}
+
+	log.Printf("Handling request for service: %s", service)
+
+	// Route to appropriate handler based on service
+	var result interface{}
+	var err error
+
+	switch service {
+	case "list_clients":
+		result, err = ps.client.FetchClients()
+	
+	case "list_sites":
+		clientID, parseErr := strconv.Atoi(r.URL.Query().Get("clientid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid clientid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		result, err = ps.client.FetchSites(clientID)
+	
+	case "list_servers":
+		siteID, parseErr := strconv.Atoi(r.URL.Query().Get("siteid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid siteid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		result, err = ps.client.FetchServers(siteID)
+	
+	case "list_workstations":
+		siteID, parseErr := strconv.Atoi(r.URL.Query().Get("siteid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid siteid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		result, err = ps.client.FetchWorkstations(siteID)
+	
+	case "list_devices":
+		siteID, parseErr := strconv.Atoi(r.URL.Query().Get("siteid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid siteid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		result, err = ps.client.FetchDevicesBySite(siteID)
+	
+	case "list_devices_at_client":
+		clientID, parseErr := strconv.Atoi(r.URL.Query().Get("clientid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid clientid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		result, err = ps.client.FetchDevices(clientID)
+	
+	case "list_device_asset_details":
+		deviceID, parseErr := strconv.Atoi(r.URL.Query().Get("deviceid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid deviceid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		result, err = ps.client.FetchDeviceAssetDetails(deviceID)
+	
+	case "list_failing_checks":
+		result, err = ps.client.FetchFailingChecks()
+	
+	case "list_checks":
+		deviceIDStr := r.URL.Query().Get("deviceid")
+		siteIDStr := r.URL.Query().Get("siteid")
+		
+		if deviceIDStr != "" {
+			deviceID, parseErr := strconv.Atoi(deviceIDStr)
+			if parseErr != nil {
+				http.Error(w, `{"error": "Invalid deviceid parameter"}`, http.StatusBadRequest)
+				return
+			}
+			result, err = ps.client.FetchChecks(deviceID)
+		} else if siteIDStr != "" {
+			siteID, parseErr := strconv.Atoi(siteIDStr)
+			if parseErr != nil {
+				http.Error(w, `{"error": "Invalid siteid parameter"}`, http.StatusBadRequest)
+				return
+			}
+			result, err = ps.client.FetchChecksBySite(siteID)
+		} else {
+			http.Error(w, `{"error": "Missing deviceid or siteid parameter"}`, http.StatusBadRequest)
+			return
+		}
+	
+	case "list_device_monitoring_details":
+		deviceID, parseErr := strconv.Atoi(r.URL.Query().Get("deviceid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid deviceid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		result, err = ps.client.FetchDeviceMonitoringDetails(deviceID)
+	
+	case "list_agentless_assets":
+		siteID, parseErr := strconv.Atoi(r.URL.Query().Get("siteid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid siteid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		result, err = ps.client.FetchAgentlessAssets(siteID)
+	
+	case "list_hardware":
+		deviceID, parseErr := strconv.Atoi(r.URL.Query().Get("deviceid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid deviceid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		result, err = ps.client.FetchHardware(deviceID)
+	
+	case "list_software":
+		deviceID, parseErr := strconv.Atoi(r.URL.Query().Get("deviceid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid deviceid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		result, err = ps.client.FetchSoftware(deviceID)
+	
+	case "list_license_groups":
+		result, err = ps.client.FetchLicenseGroups()
+	
+	case "list_patches":
+		deviceID, parseErr := strconv.Atoi(r.URL.Query().Get("deviceid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid deviceid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		result, err = ps.client.FetchPatches(deviceID)
+	
+	case "list_antivirus_products":
+		result, err = ps.client.FetchAntivirusProducts()
+	
+	case "list_antivirus_definitions":
+		deviceID, parseErr := strconv.Atoi(r.URL.Query().Get("deviceid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid deviceid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		result, err = ps.client.FetchAntivirusDefinitions(deviceID)
+	
+	case "list_quarantine":
+		deviceID, parseErr := strconv.Atoi(r.URL.Query().Get("deviceid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid deviceid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		result, err = ps.client.FetchQuarantineList(deviceID)
+	
+	case "list_performance_history":
+		deviceID, parseErr := strconv.Atoi(r.URL.Query().Get("deviceid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid deviceid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		checkID, parseErr := strconv.Atoi(r.URL.Query().Get("checkid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid checkid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		startDate := r.URL.Query().Get("startdate")
+		endDate := r.URL.Query().Get("enddate")
+		result, err = ps.client.FetchPerformanceHistory(deviceID, checkID, startDate, endDate)
+	
+	case "list_drive_space_history":
+		deviceID, parseErr := strconv.Atoi(r.URL.Query().Get("deviceid"))
+		if parseErr != nil {
+			http.Error(w, `{"error": "Invalid deviceid parameter"}`, http.StatusBadRequest)
+			return
+		}
+		startDate := r.URL.Query().Get("startdate")
+		endDate := r.URL.Query().Get("enddate")
+		result, err = ps.client.FetchDriveSpaceHistory(deviceID, startDate, endDate)
+	
+	case "list_templates":
+		result, err = ps.client.FetchTemplates()
+	
+	default:
+		http.Error(w, fmt.Sprintf(`{"error": "Unsupported service: %s"}`, service), http.StatusBadRequest)
+		return
+	}
+
+	// Handle any error from the API call
+	if err != nil {
+		log.Printf("Error calling API service %s: %v", service, err)
+		http.Error(w, fmt.Sprintf(`{"error": "API call failed: %s"}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+
+	// Convert result to JSON
+	jsonData, err := json.Marshal(result)
+	if err != nil {
+		log.Printf("Error marshaling JSON for service %s: %v", service, err)
+		http.Error(w, `{"error": "Failed to convert response to JSON"}`, http.StatusInternalServerError)
+		return
+	}
+
+	// Write JSON response
+	w.Write(jsonData)
+}
+
+// healthCheck provides a simple health check endpoint
+func (ps *ProxyServer) healthCheck(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(`{"status": "ok", "service": "nsight-proxy"}`))
+}
+
+func main() {
+	log.Println("Starting N-Sight JSON Proxy Server...")
+
+	// Create proxy server instance
+	proxy, err := NewProxyServer()
+	if err != nil {
+		log.Fatalf("Failed to initialize proxy server: %v", err)
+	}
+
+	// Set up routes
+	http.HandleFunc("/api/", proxy.handleAPI)
+	http.HandleFunc("/health", proxy.healthCheck)
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"service": "N-Sight JSON Proxy", "version": "1.0", "endpoints": ["/api/", "/health"]}`))
+	})
+
+	// Start server on port 80
+	log.Println("Server starting on port 80...")
+	log.Println("API endpoint: http://localhost/api/?service=<service_name>&<parameters>")
+	log.Println("Health check: http://localhost/health")
+	
+	if err := http.ListenAndServe(":80", nil); err != nil {
+		log.Fatalf("Server failed to start: %v", err)
+	}
+}

--- a/internal/nsight/api.go
+++ b/internal/nsight/api.go
@@ -40,6 +40,15 @@ func NewApiClient() (*ApiClient, error) {
 	return &ApiClient{apiKey: apiKey, server: server}, nil
 }
 
+// NewApiClientWithCredentials creates a new ApiClient with provided API key and server
+func NewApiClientWithCredentials(apiKey, server string) (*ApiClient, error) {
+	if apiKey == "" || server == "" {
+		return nil, errors.New("apiKey and server must not be empty")
+	}
+
+	return &ApiClient{apiKey: apiKey, server: server}, nil
+}
+
 // callAPI performs the HTTP GET request and returns the response body bytes
 func (c *ApiClient) callAPI(service string, params map[string]string) ([]byte, error) {
 	base, err := url.Parse(fmt.Sprintf("https://%s/api/", c.server))


### PR DESCRIPTION
Add `cmd/nsight-proxy` to provide a JSON proxy for N-Sight API, requiring API key per request.

This new tool acts as a translator, converting the N-Sight API's XML output to JSON. A key security requirement was to ensure the API key is passed in the URL for each request, preventing anonymous access and allowing individual users to use their own keys, rather than relying on a shared key from environment variables.